### PR TITLE
Fixed issues with windows 7 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,82 +2,65 @@
 
 try {
     stage('Checkout') {
-        parallel UbuntuEmscripten: {
-            node('UbuntuEmscripten') {
-                checkout scm
-            }
-        },
-        RaspianJessie: {
-            node('RaspianJessie') {
-                checkout scm
-            }
-        },
-        MacOSSierra: {
-            node('MacOSSierra') {
-                checkout scm
-            }
-        },
-        FedoraGcc: {
-            node('FedoraGcc') {
-                checkout scm
-            }
-        },
-        UbuntuGcc: {
-            node('UbuntuGcc') {
-                checkout scm
-            }
-        },
-        UbuntuClang: {
-            node('UbuntuClang') {
-                checkout scm
-            }
-        }
+        parallel FedoraGcc: { node('FedoraGcc') {
+            checkout scm
+        } },
+        MacOSSierra: { node('MacOSSierra') {
+            checkout scm
+        } },
+        RaspianJessie: { node('RaspianJessie') {
+            checkout scm
+        } },
+        UbuntuClang: { node('UbuntuClang') {
+            checkout scm
+        } },
+        UbuntuEmscripten: { node('UbuntuEmscripten') {
+            checkout scm
+        } },
+        UbuntuGcc: { node('UbuntuGcc') {
+            checkout scm
+        } },
+        windows7Mingw32: { node('windows7Mingw32') {
+            checkout scm
+        } },
+        windows7Mingw64: { node('windows7Mingw64') {
+            checkout scm
+        } },
+        windows7msvc: { node('windows7msvc') {
+            checkout scm
+        } }
     }
 
     stage('Test') {
-        parallel UbuntuEmscripten: {
-            node('UbuntuEmscripten') {
-                sh """ cd Test                                                                                        &&
-                       ruby RootTest.rb
-                """
+        parallel FedoraGcc: { node('FedoraGcc') {
+            dir('Test') { sh 'ruby RootTest.rb' }
+        } },
+        MacOSSierra: { node('MacOSSierra') {
+            dir('Test') { sh 'export PATH=$PATH:/usr/local/bin/ && ruby RootTest.rb' }
+        } },
+        RaspianJessie: { node('RaspianJessie') {
+            dir('Test') { sh 'ruby RootTest.rb' }
+        } },
+        UbuntuClang: { node('UbuntuClang') {
+            dir('Test') { sh 'ruby RootTest.rb' }
+        } },
+        UbuntuEmscripten: { node('UbuntuEmscripten') {
+            dir('Test') { sh 'ruby RootTest.rb' }
+        } },
+        UbuntuGcc: { node('UbuntuGcc') {
+            dir('Test') { sh 'ruby RootTest.rb' }
+        } },
+        windows7Mingw32: { node('windows7Mingw32') {
+            dir('Test') { bat 'ruby RootTest.rb -G MinGW Makefiles' }
+        } },
+        windows7Mingw64: { node('windows7Mingw64') {
+            dir('Test') { bat 'ruby RootTest.rb -G MinGW Makefiles' }
+        } },
+        windows7msvc: { node('windows7msvc') {
+            dir('Test') {
+                bat '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64 && ruby RootTest.rb -G "Visual Studio 15 2017 Win64"'
             }
-        },
-        RaspianJessie: {
-            node('RaspianJessie') {
-                sh """ cd Test                                                                                        &&
-                       ruby RootTest.rb
-                """
-            }
-        },
-        MacOSSierra: {
-            node('MacOSSierra') {
-                sh """ cd Test                                                                                        &&
-                       export PATH=$PATH:/usr/local/bin/                                                              &&
-                       ruby RootTest.rb
-                """
-            }
-        },
-        FedoraGcc: {
-            node('FedoraGcc') {
-                sh """ cd Test                                                                                        &&
-                       ruby RootTest.rb
-                """
-            }
-        },
-        UbuntuGcc: {
-            node('UbuntuGcc') {
-                sh """ cd Test                                                                                        &&
-                       ruby RootTest.rb
-                """
-            }
-        },
-        UbuntuClang: {
-            node('UbuntuClang') {
-                sh """ cd Test                                                                                        &&
-                       ruby RootTest.rb
-                """
-            }
-        }
+        } }
     }
 
     stage('SendMail') {

--- a/Test/CMake.rb
+++ b/Test/CMake.rb
@@ -15,6 +15,10 @@ class CMake
     attr_reader :invocation_stdout
     attr_reader :invocation_stderr
 
+    class << self
+        attr_accessor :generator
+    end
+
     def initialize(source_dir, build_dir = "#{source_dir}/build")
         @source_dir = Pathname.new(source_dir).realpath
         FileUtils::mkdir_p build_dir
@@ -44,7 +48,8 @@ class CMake
     end
 
     def invocation_string
-        arg_string = @args.collect { |k,v| " -D#{k}=#{v}" }.join
+        arg_string = if CMake.generator.nil? then "" else " -G\"#{CMake.generator}\"" end
+        arg_string += @args.collect { |k,v| " -D#{k}=#{v}" }.join
         "cmake #{source_dir}#{arg_string}"
     end
 

--- a/Test/CMakeCache.rb
+++ b/Test/CMakeCache.rb
@@ -53,9 +53,7 @@ class CMakeCache
     end
 
     def value(name)
-        cleaned = @value_cache[name]
-        cleaned[0] = cleaned[0].downcase if !cleaned.nil? && cleaned.size > 2 && cleaned[1] == ':'
-        cleaned
+        samecase_drive(@value_cache[name])
     end
     
     def type(name)

--- a/Test/CMakeCache.rb
+++ b/Test/CMakeCache.rb
@@ -53,7 +53,9 @@ class CMakeCache
     end
 
     def value(name)
-        @value_cache[name]
+        cleaned = @value_cache[name]
+        cleaned[0] = cleaned[0].downcase if !cleaned.nil? && cleaned.size > 2 && cleaned[1] == ':'
+        cleaned
     end
     
     def type(name)

--- a/Test/LocationVars/test.rb
+++ b/Test/LocationVars/test.rb
@@ -13,15 +13,15 @@ class TestLocationVars < TestCase
         # The CMake test class decided the source and build dirs, it should know the correct answer got these tests.
         assert_equal(cmake.build_dir.with_slash,
                      cmake.cache.value('LocationVarsTest_BinaryDir'),
-                     'Jagati Sets ${PROJECT_NAME}BinaryDir to our build dir correctly.')
+                     'Jagati Sets ${PROJECT_NAME}BinaryDir to our build dir correctly')
         assert_equal(cmake.source_dir.with_slash,
                      cmake.cache.value('LocationVarsTest_RootDir'),
-                     'Jagati Sets ${PROJECT_NAME}RootDir to our build dir correctly.')
+                     'Jagati Sets ${PROJECT_NAME}RootDir to our build dir correctly')
 
         # This just tests that our CMake test gets the project name correctly.
         assert_equal('LocationVarsTest_',
                      cmake.cache.project_name,
-                     'Jagati Sets ${PROJECT_NAME}RootDir to our build dir correctly.')
+                     'Jagati Sets ${PROJECT_NAME}RootDir to our build dir correctly')
 
         # These tests all come in pairs. First we test that the Jagati produces the correct value, then we test that
         # value in cmake matches the value the testing shortcuts produce. Even if that value is wrong, as long as they
@@ -30,49 +30,49 @@ class TestLocationVars < TestCase
         # Test Jagati with Doxygen
         assert_equal(cmake.source_dir.with_slash + 'dox/',
                      cmake.cache.value('LocationVarsTest_DoxDir'),
-                     'Jagati Sets ${PROJECT_NAME}_DoxDir to the doxygen directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_DoxDir to the doxygen directory correctly')
         # Verify Test Tooling  with Doxygen
         assert_equal(cmake.cache.value('LocationVarsTest_DoxDir'),
                      cmake.jagati.doxygen_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_DoxDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_DoxDir value')
 
         # Test Jagati and Verify Test Tooling with the header directory this package exposes
         assert_equal(cmake.source_dir.with_slash + 'include/',
                      cmake.cache.value('LocationVarsTest_IncludeDir'),
-                     'Jagati Sets ${PROJECT_NAME}_IncludeDir to the include directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_IncludeDir to the include directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_IncludeDir'),
                      cmake.jagati.include_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_IncludeDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_IncludeDir value')
 
         # Test Jagati and Verify Test Tooling with library directory this package exposes
         assert_equal(cmake.source_dir.with_slash + 'lib/',
                      cmake.cache.value('LocationVarsTest_LibDir'),
-                     'Jagati Sets ${PROJECT_NAME}_LibDir to the library directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_LibDir to the library directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_LibDir'),
                      cmake.jagati.library_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_LibDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_LibDir value')
 
         # Test Jagati and Verify Test Tooling with Source directory this package sets, and shouldn't be considered
         # exposed
         assert_equal(cmake.source_dir.with_slash + 'src/',
                      cmake.cache.value('LocationVarsTest_SourceDir'),
-                     'Jagati Sets ${PROJECT_NAME}_SourceDir to the Source directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_SourceDir to the Source directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_SourceDir'),
                      cmake.jagati.source_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_SourceDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_SourceDir value')
 
         # Test Jagati and Verify Test Tooling with the SWIG directory this package exposed
         assert_equal(cmake.source_dir.with_slash + 'swig/',
                      cmake.cache.value('LocationVarsTest_SwigDir'),
-                     'Jagati Sets ${PROJECT_NAME}_SwigDir to the SWIG directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_SwigDir to the SWIG directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_SwigDir'),
                      cmake.jagati.swig_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_SwigDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_SwigDir value')
 
         # Test Jagati and Verify Test Tooling with the directory this package puts test source in.
         assert_equal(cmake.source_dir.with_slash + 'test/',
                      cmake.cache.value('LocationVarsTest_TestDir'),
-                     'Jagati Sets ${PROJECT_NAME}_TestDir to the test directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_TestDir to the test directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_TestDir'),
                      cmake.jagati.test_dir,
                      'CMakeJagati.rb retrieves LocationVarsTest_TestDir value.')
@@ -85,19 +85,19 @@ class TestLocationVars < TestCase
         # Test Jagati and Verify Test Tooling with the directory for autogenerated configuration headers.
         assert_equal(cmake.build_dir.with_slash + 'config/',
                      cmake.cache.value('LocationVarsTest_GenHeadersDir'),
-                     'Jagati Sets ${PROJECT_NAME}_GenHeadersDir to the test the config header directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_GenHeadersDir to the test the config header directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_GenHeadersDir'),
                      cmake.jagati.generated_header_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_GenHeadersDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_GenHeadersDir value')
         assert(File.directory?(cmake.jagati.generated_header_dir),"Test that Generated Header directory exists")
 
         # Test Jagati and Verify Test Tooling with the directory for machine generated source files.
         assert_equal(cmake.build_dir.with_slash + 'generated_source/',
                      cmake.cache.value('LocationVarsTest_GenSourceDir'),
-                     'Jagati Sets ${PROJECT_NAME}_GenSourceDir to the test generated source directory correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_GenSourceDir to the test generated source directory correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_GenSourceDir'),
                      cmake.jagati.generated_source_dir,
-                     'CMakeJagati.rb retrieves LocationVarsTest_GenSourceDir value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_GenSourceDir value')
         assert(File.directory?(cmake.jagati.generated_header_dir),"Test that Generated Source directory exists")
     end
 
@@ -109,25 +109,25 @@ class TestLocationVars < TestCase
         # Test Jagati and Verify Test Tooling with the binary target name.
         assert_equal('LocationVarsTest_',
                      cmake.cache.value('LocationVarsTest_BinTarget'),
-                     'Jagati Sets ${PROJECT_NAME}_BinTarget sets the binary target name correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_BinTarget sets the binary target name correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_BinTarget'),
                      cmake.jagati.binary_target_name,
-                     'CMakeJagati.rb retrieves LocationVarsTest_BinTarget value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_BinTarget value')
                      
         # Test Jagati and Verify Test Tooling with the library target name.
         assert_equal('LocationVarsTest_',
                      cmake.cache.value('LocationVarsTest_LibTarget'),
-                     'Jagati Sets ${PROJECT_NAME}_LibTarget sets the library target name correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_LibTarget sets the library target name correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_LibTarget'),
                      cmake.jagati.library_target_name,
-                     'CMakeJagati.rb retrieves LocationVarsTest_LibTarget value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_LibTarget value')
                      
         # Test Jagati and Verify Test Tooling with the unit test target name.
         assert_equal('LocationVarsTest__Tester',
                      cmake.cache.value('LocationVarsTest_TestTarget'),
-                     'Jagati Sets ${PROJECT_NAME}_TestTarget sets the unit test target name correctly.')
+                     'Jagati Sets ${PROJECT_NAME}_TestTarget sets the unit test target name correctly')
         assert_equal(cmake.cache.value('LocationVarsTest_TestTarget'),
                      cmake.jagati.test_target_name,
-                     'CMakeJagati.rb retrieves LocationVarsTest_TestTarget value.')
+                     'CMakeJagati.rb retrieves LocationVarsTest_TestTarget value')
     end
 end

--- a/Test/Mezz_PackageDirectory/test.rb
+++ b/Test/Mezz_PackageDirectory/test.rb
@@ -11,13 +11,13 @@ class TestPackageDirectory < TestCase
     def test_cmake
         cmake = CMake.new(@source_dir)
 
-        refute_equal(@source_dir.size, cmake.source_dir.size, 'Cmake class should convert to absolute path.')
-        assert_match(/build$/, cmake.build_dir.to_s, 'Cmake class should pick a sane build directory.')
+        refute_equal(@source_dir.size, cmake.source_dir.size, 'Cmake class should convert to absolute path')
+        assert_match(/build$/, cmake.build_dir.to_s, 'Cmake class should pick a sane build directory')
 
         cmake.add_argument 'name', 'value'
         cmake.add_argument 'typedname', 'typedValue', 'STRING'
         cmake.add_argument 'CMAKE_BUILD_TYPE', 'debug'
-        assert_match(/-Dname=value/, cmake.invocation_string, 'Cmake args are in correct format.')
+        assert_match(/-Dname=value/, cmake.invocation_string, 'Cmake args are in correct format')
 
         cache = cmake.cache
         cache.remove_file
@@ -25,11 +25,11 @@ class TestPackageDirectory < TestCase
 
         cmake.invoke
         cache.load_cache # This reads the file
-        assert_equal(true, cache.file_valid?, 'When cmake runs it should create a cache file.')
-        assert_equal('value', cache.value('name'), 'Custom Values can be read from the CMakeCache.')
-        assert_equal('typedValue', cache.value('typedname'), 'Custom Typed Values can be read from the CMakeCache.')
-        assert_equal('STRING', cache.type('typedname'), 'Types can be read from the CMakeCache.')
-        assert_equal('debug', cache.value('CMAKE_BUILD_TYPE'), 'Normal Values can be read from the CMakeCache.')
+        assert_equal(true, cache.file_valid?, 'When cmake runs it should create a cache file')
+        assert_equal('value', cache.value('name'), 'Custom Values can be read from the CMakeCache')
+        assert_equal('typedValue', cache.value('typedname'), 'Custom Typed Values can be read from the CMakeCache')
+        assert_equal('STRING', cache.type('typedname'), 'Types can be read from the CMakeCache')
+        assert_equal('debug', cache.value('CMAKE_BUILD_TYPE'), 'Normal Values can be read from the CMakeCache')
     end
     
     def test_default_location
@@ -40,19 +40,19 @@ class TestPackageDirectory < TestCase
         cmake.invoke
 
         # Does the Jagati pick a good location in the Build directory?
-        expected_dir = "#{Dir.pwd}/#{@source_dir}/build/JagatiPackages"        
-        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Has sane default package dir.')
+        expected_dir = "#{Dir.lpwd}/#{@source_dir}/build/JagatiPackages"        
+        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Has sane default package dir')
 
         # Does the warning look good?
         assert_match(/CMake Warning/, cmake.invocation_stderr.join, 'There is a warning')
         assert_match(/Environment\s*variable[ \t']*MEZZ_PACKAGE_DIR/, cmake.invocation_stderr.join,
             'The warning mentions the environment variable')
-        assert_match(/MEZZ_PackageDirectory/, cmake.invocation_stderr.join, 'The warning mentions the cmake setting.')
+        assert_match(/MEZZ_PackageDirectory/, cmake.invocation_stderr.join, 'The warning mentions the cmake setting')
         
     end
     
     def test_location_from_env
-        package_dir = "#{Dir.pwd}/#{@source_dir}/build/foo"
+        package_dir = "#{Dir.lpwd}/#{@source_dir}/build/foo"
         FileUtils::mkdir_p package_dir
         ENV['MEZZ_PACKAGE_DIR'] = package_dir
 
@@ -61,13 +61,13 @@ class TestPackageDirectory < TestCase
         cmake.invoke
 
         expected_dir = package_dir
-        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Reads MEZZ_PACKAGE_DIR Dir from ENV.')
+        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Reads MEZZ_PACKAGE_DIR Dir from ENV')
     end
     
     def test_location_from_arg
         ENV.delete('MEZZ_PACKAGE_DIR')
         
-        package_dir = "#{Dir.pwd}/#{@source_dir}/build/foo"
+        package_dir = "#{Dir.lpwd}/#{@source_dir}/build/foo"
         FileUtils::mkdir_p package_dir
 
         cmake = CMake.new(@source_dir)
@@ -76,7 +76,7 @@ class TestPackageDirectory < TestCase
         cmake.invoke
 
         expected_dir = package_dir
-        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Respects passed MEZZ_PackageDirectory.')
+        assert_equal(expected_dir, cmake.cache.value('MEZZ_PackageDirectory'), 'Respects passed MEZZ_PackageDirectory')
     end
 
 end

--- a/Test/RootTest.rb
+++ b/Test/RootTest.rb
@@ -24,19 +24,24 @@ rescue
     TestCase = MiniTest::Unit::TestCase
 end
 
-# Problems with trailing slashes were common, so we added this
-class ::Pathname
-    def with_slash
-        to_s + '/'
+# Dir doesn't guarantee a case on #pwd, this allows us 
+def samecase_drive(path)
+    if path.nil? then return nil end
+    cleaned = path.to_s
+    cleaned[0] = cleaned[0].upcase if cleaned.size > 2 && cleaned[1] == ':'
+    cleaned
+end
+
+class Dir
+    def self.lpwd
+        samecase_drive(Dir.pwd)
     end
 end
 
-# Dir doesn't guarantee a case on pwd.
-class Dir
-    def self.lpwd
-        cleaned = Dir.pwd
-        cleaned[0] = cleaned[0].downcase if !cleaned.nil? && cleaned.size > 2 && cleaned[1] == ':'
-        cleaned
+# Problems with trailing slashes were common, so we added this
+class ::Pathname
+    def with_slash
+        samecase_drive(to_s + '/')
     end
 end
 

--- a/Test/RootTest.rb
+++ b/Test/RootTest.rb
@@ -8,6 +8,14 @@ require_relative 'CMakeCache'
 require_relative 'CMakeJagati'
 require_relative 'CMake'
 
+require 'optparse'
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby RootTest.rb [-G Optional Cmake Generator] [-h|--help]"
+  opts.on('-G', '--Generator NAME', 'Name of CMake Generator') { |v| CMake.generator = v }
+  opts.on('-h', '--help', 'See this help message') { |v| puts opts; exit; }
+end.parse!
+
 # Pick some test Suite in the standard library and give it some alias all our tests will use.
 require 'minitest/autorun'
 begin
@@ -20,6 +28,15 @@ end
 class ::Pathname
     def with_slash
         to_s + '/'
+    end
+end
+
+# Dir doesn't guarantee a case on pwd.
+class Dir
+    def self.lpwd
+        cleaned = Dir.pwd
+        cleaned[0] = cleaned[0].downcase if !cleaned.nil? && cleaned.size > 2 && cleaned[1] == ':'
+        cleaned
     end
 end
 


### PR DESCRIPTION
Added Dir.lpwd to consistently get lowercase drive letters
CMakeCache#value checks for drive letter in values and return lowercase.

Removed '.' from assert messages because TestUnit does this.

Added -G option to match cmakes generator selection and allow greater variety in tests beyond default compiler
Added -h option to see help.